### PR TITLE
fix: Switch name of jx postsubmit job

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -320,7 +320,7 @@ postsubmits:
     - master
   jenkins-x/jx:
   - agent: tekton
-    name: tekton
+    name: release
     branches:
     - master
   jenkins-x/jx-datadog:


### PR DESCRIPTION
So if `context` isn't specified, Prow will use `name` as the
`context`, which means that it's still going to look for
`jenkins-x-tekton.yml`, and if it exists, it'll use *that* as the
source for the pipeline...which blows up if there isn't a release
pipeline in it. So. Yeah.

If this works, I'll probably be updating all the postsubmits to have
no `context` and have `release` as the `name.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>