### PR TITLE
Revert "feat: removed hound from the required context"

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -1050,6 +1050,7 @@ tide:
             - integration
             - lint
             - bdd
+            - Hound
   queries:
   - labels:
     - approved


### PR DESCRIPTION
Reverts jenkins-x/prow-config-tekton#92

Hound seems to be functioning within PRs now that their certificate has been renewed