### PR TITLE
chore: Run tekton and bdd for jx.git on postsubmit to master

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -141,7 +141,7 @@ branch-protection:
         jx:
           required_status_checks:
             contexts:
-              ["bdd","integration","lint","tekton"]
+              ["bdd","tekton","integration","lint"]
         jx-datadog:
           required_status_checks:
             contexts: ["tekton"]

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -476,6 +476,16 @@ postsubmits:
     name: release
     branches:
     - master
+  - agent: tekton
+    context: bdd
+    name: bdd
+    branches:
+    - master
+  - agent: tekton
+    context: tekton
+    name: tekton
+    branches:
+      - master
   jenkins-x/jx-datadog:
   - agent: tekton
     context: tekton


### PR DESCRIPTION
This saves us having to wait for bdd+tekton to finish on releases,
since all they're doing is running the normal bdd and tekton pipeline
contents in the first place.

cc @pmuir @garethjevans 
