### PR TITLE
chore: Remove baseline tekton and bdd for codecov on jx releases

### DIFF
--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -524,16 +524,6 @@ postsubmits:
     name: release
     branches:
     - master
-  - agent: tekton
-    context: bdd
-    name: bdd
-    branches:
-    - master
-  - agent: tekton
-    context: tekton
-    name: tekton
-    branches:
-      - master
   jenkins-x/jx-datadog:
   - agent: tekton
     context: tekton


### PR DESCRIPTION
This never actually worked anyway, so hey, since we're getting rid of codecov, now I don't have to try to figure out how to fix them. =)

/assign @pmuir 
/assign @garethjevans 
